### PR TITLE
Remove assumption that script is being run by pi

### DIFF
--- a/MakeOVPN.sh
+++ b/MakeOVPN.sh
@@ -8,6 +8,8 @@ OKEY=".key"
 KEY=".3des.key" 
 CA="ca.crt" 
 TA="ta.key" 
+SCRIPT_DIR=$(pwd)
+
 
 #Ask for a Client name
 #NAME=$(whiptail --inputbox "Please enter a Name for the Client:" \
@@ -84,10 +86,10 @@ cat $TA >> $NAME$FILEEXT
 echo "</tls-auth>" >> $NAME$FILEEXT 
 
 # Copy the .ovpn profile to the home directory for convenient remote access
-cp /etc/openvpn/easy-rsa/keys/$NAME$FILEEXT /home/pi/ovpns/$NAME$FILEEXT
+cp /etc/openvpn/easy-rsa/keys/$NAME$FILEEXT $SCRIPT_DIR/ovpns/$NAME$FILEEXT
 sudo chmod 600 -R /etc/openvpn
-echo "$NAME$FILEEXT moved to home directory."
+echo "$NAME$FILEEXT moved to $SCRIPT_DIR."
 whiptail --title "MakeOVPN" --msgbox "Done! $NAME$FILEEXT successfully created and \
-moved to directory /home/pi/ovpns." 8 78
+moved to directory ${SCRIPT_DIR}/ovpns." 8 78
  
 # Original script written by Eric Jodoin.

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(pwd)
+
 if (whiptail --title "Setup OpenVPN" --yesno "You are about to configure your \
 Raspberry Pi as a VPN server running OpenVPN. Are you sure you want to \
 continue?" 8 78) then
@@ -63,7 +65,7 @@ source ./vars
 ./clean-all
 
 # Build the certificate authority
-./build-ca < /home/pi/OpenVPN-Setup/ca_info.txt
+./build-ca < $SCRIPT_DIR/ca_info.txt
 
 whiptail --title "Setup OpenVPN" --msgbox "You will now be asked for identifying \
 information for the server. Press 'Enter' to skip a field." 8 78
@@ -78,7 +80,7 @@ information for the server. Press 'Enter' to skip a field." 8 78
 openvpn --genkey --secret keys/ta.key
 
 # Write config file for server using the template .txt file
-sed 's/LOCALIP/'$LOCALIP'/' </home/pi/OpenVPN-Setup/server_config.txt >/etc/openvpn/server.conf
+sed 's/LOCALIP/'$LOCALIP'/' < $SCRIPT_DIR/server_config.txt >/etc/openvpn/server.conf
 if [ $ENCRYPT = 2048 ]; then
  sed -i 's:dh1024:dh2048:' /etc/openvpn/server.conf
 fi
@@ -89,20 +91,20 @@ net.ipv4.ip_forward=1' /etc/sysctl.conf
 sudo sysctl -p
 
 # Write script to allow openvpn through firewall on boot using the template .txt file
-sed 's/LOCALIP/'$LOCALIP'/' </home/pi/OpenVPN-Setup/firewall-openvpn-rules.txt >/etc/firewall-openvpn-rules.sh
+sed 's/LOCALIP/'$LOCALIP'/' < $SCRIPT_DIR/firewall-openvpn-rules.txt >/etc/firewall-openvpn-rules.sh
 sudo chmod 700 /etc/firewall-openvpn-rules.sh
 sudo chown root /etc/firewall-openvpn-rules.sh
 sed -i -e '$i \/etc/firewall-openvpn-rules.sh\n' /etc/rc.local
 
 # Write default file for client .ovpn profiles, to be used by the MakeOVPN script, using template .txt file
-sed 's/PUBLICIP/'$PUBLICIP'/' </home/pi/OpenVPN-Setup/Default.txt >/etc/openvpn/easy-rsa/keys/Default.txt
+sed 's/PUBLICIP/'$PUBLICIP'/' < $SCRIPT_DIR/Default.txt >/etc/openvpn/easy-rsa/keys/Default.txt
 
 # Make directory under home directory for .ovpn profiles
-mkdir /home/pi/ovpns
-chmod 777 -R /home/pi/ovpns
+mkdir $SCRIPT_DIR/ovpns
+chmod 777 -R $SCRIPT_DIR/ovpns
 
 # Make other scripts in the package executable
-cd /home/pi/OpenVPN-Setup
+cd $SCRIPT_DIR
 sudo chmod +x MakeOVPN.sh
 sudo chmod +x remove.sh
 

--- a/remove.sh
+++ b/remove.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SCRIPT_DIR=$(pwd)
+
+
 # Ask user for confirmation
 if (whiptail --title "Remove OpenVPN" --yesno --defaultno "Are you sure you want to remove \
 OpenVPN and revert your system to its previous state?" 8 78) then
@@ -13,7 +16,7 @@ fi
 apt-get -y remove openvpn
 
 # Remove openvpn-related directories
-rm -r /etc/openvpn /home/pi/ovpns
+rm -r /etc/openvpn $SCRIPT_DIR/ovpns
 
 # Remove firewall script and reference to it in interfaces
 sed -i '/firewall-openvpn-rules.sh/d' /etc/rc.local


### PR DESCRIPTION
Currently this set of script assumes that the user running them is pi.
This update removes that assumption.

This also moves the `ovpns` folder from `/home/pi/` to the directory that the contains the script.

Closes #30 and #3 