### PR TITLE
Add dist-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Git. If you don't already have it, update your APT repositories and install it:
 ```shell
 sudo apt-get update
 sudo apt-get upgrade
+sudo apt-get dist-upgrade
 sudo apt-get install git
 ```
 


### PR DESCRIPTION
The readme instructions doesn't take into consideration that dist-upgrade may need to be run since apt upgrade may not upgrade every package that is available.