### PR TITLE
Use paths appropriate for logged-in user instead of 'pi'

### DIFF
--- a/MakeOVPN.sh
+++ b/MakeOVPN.sh
@@ -84,10 +84,10 @@ cat $TA >> $NAME$FILEEXT
 echo "</tls-auth>" >> $NAME$FILEEXT 
 
 # Copy the .ovpn profile to the home directory for convenient remote access
-cp /etc/openvpn/easy-rsa/keys/$NAME$FILEEXT /home/pi/ovpns/$NAME$FILEEXT
+cp /etc/openvpn/easy-rsa/keys/$NAME$FILEEXT /home/`logname`/ovpns/$NAME$FILEEXT
 sudo chmod 600 -R /etc/openvpn
 echo "$NAME$FILEEXT moved to home directory."
 whiptail --title "MakeOVPN" --msgbox "Done! $NAME$FILEEXT successfully created and \
-moved to directory /home/pi/ovpns." 8 78
+moved to directory /home/`logname`/ovpns." 8 78
  
 # Original script written by Eric Jodoin.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if (whiptail --title "Setup OpenVPN" --yesno "You are about to configure your \
-Raspberry Pi as a VPN server running OpenVPN. Are you sure you want to \
+Raspberry Pi as a VPN server running OpenVPN as user `logname`. Are you sure you want to \
 continue?" 8 78) then
  whiptail --title "Setup OpenVPN" --infobox "OpenVPN will be installed and \
  configured." 8 78
@@ -63,7 +63,7 @@ source ./vars
 ./clean-all
 
 # Build the certificate authority
-./build-ca < /home/pi/OpenVPN-Setup/ca_info.txt
+./build-ca < /home/`logname`/OpenVPN-Setup/ca_info.txt
 
 whiptail --title "Setup OpenVPN" --msgbox "You will now be asked for identifying \
 information for the server. Press 'Enter' to skip a field." 8 78
@@ -78,7 +78,7 @@ information for the server. Press 'Enter' to skip a field." 8 78
 openvpn --genkey --secret keys/ta.key
 
 # Write config file for server using the template .txt file
-sed 's/LOCALIP/'$LOCALIP'/' </home/pi/OpenVPN-Setup/server_config.txt >/etc/openvpn/server.conf
+sed 's/LOCALIP/'$LOCALIP'/' </home/`logname`/OpenVPN-Setup/server_config.txt >/etc/openvpn/server.conf
 if [ $ENCRYPT = 2048 ]; then
  sed -i 's:dh1024:dh2048:' /etc/openvpn/server.conf
 fi
@@ -89,21 +89,21 @@ net.ipv4.ip_forward=1' /etc/sysctl.conf
 sudo sysctl -p
 
 # Write script to run openvpn and allow it through firewall on boot using the template .txt file
-sed 's/LOCALIP/'$LOCALIP'/' </home/pi/OpenVPN-Setup/firewall-openvpn-rules.txt >/etc/firewall-openvpn-rules.sh
+sed 's/LOCALIP/'$LOCALIP'/' </home/`logname`/OpenVPN-Setup/firewall-openvpn-rules.txt >/etc/firewall-openvpn-rules.sh
 sudo chmod 700 /etc/firewall-openvpn-rules.sh
 sudo chown root /etc/firewall-openvpn-rules.sh
 sed -i -e '$i \/etc/firewall-openvpn-rules.sh\n' /etc/rc.local
 sed -i -e '$i \sudo service openvpn start\n' /etc/rc.local
 
 # Write default file for client .ovpn profiles, to be used by the MakeOVPN script, using template .txt file
-sed 's/PUBLICIP/'$PUBLICIP'/' </home/pi/OpenVPN-Setup/Default.txt >/etc/openvpn/easy-rsa/keys/Default.txt
+sed 's/PUBLICIP/'$PUBLICIP'/' </home/`logname`/OpenVPN-Setup/Default.txt >/etc/openvpn/easy-rsa/keys/Default.txt
 
 # Make directory under home directory for .ovpn profiles
-mkdir /home/pi/ovpns
-chmod 777 -R /home/pi/ovpns
+mkdir /home/`logname`/ovpns
+chmod 777 -R /home/`logname`/ovpns
 
 # Make other scripts in the package executable
-cd /home/pi/OpenVPN-Setup
+cd /home/`logname`/OpenVPN-Setup
 sudo chmod +x MakeOVPN.sh
 sudo chmod +x remove.sh
 

--- a/remove.sh
+++ b/remove.sh
@@ -13,7 +13,7 @@ fi
 apt-get -y remove openvpn
 
 # Remove openvpn-related directories
-rm -r /etc/openvpn /home/pi/ovpns
+rm -r /etc/openvpn /home/`logname`/ovpns
 
 # Remove firewall script and reference to it in interfaces
 sed -i '/firewall-openvpn-rules.sh/d' /etc/rc.local


### PR DESCRIPTION
Allows script to work for users other than 'pi'. Uses 'logname' to get name of user for the current session.